### PR TITLE
Updated README considering it was a bit outdated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 Welcome to the free speech internet.  Dissenter is a fork of the [Brave browser](https://github.com/brave/brave-browser), so it's fast and it blocks ads and 3rd-party trackers.  The Dissenter extension, which creates a comment section for any and every page on the internet, is built right in.  We're just getting started, we have big future plans for this browser.
 
-## Status
-
-Focus was on the overall repo and getting a Windows build done.  The latest Windows installer is here: [Download](https://dissenter.com/dist/browser/dissenter_installer_74_0_66_49.exe)
-
-Known issues: Can't set Dissenter as default web browser yet.
-
 ## Overview 
 
 This repository holds the build tools needed to build the Dissenter desktop browser for macOS, Windows, and Linux.  In particular, it fetches and syncs code from the projects defined in `package.json` and `src/brave/DEPS`:
@@ -37,8 +31,8 @@ You can [visit our website](https://dissenter.com/) to get the latest stable rel
 
 For other versions of our browser, please see:
 
-* iOS - [gab-ai-inc/defiant-ios](https://github.com/gab-ai-inc/defiant-ios)
-* Android - [gab-ai-inc/defiant-android](https://github.com/gab-ai-inc/defiant-android)
+* iOS - Coming soon.
+* Android - Coming soon.
 
 ## Community
 


### PR DESCRIPTION
- Removed the "Known issues: Can't set Dissenter as default web browser yet." part, this has been fixed for a very long time.
- The download link is very old and uses an outdated version of Dissenter.
- Android/iOS source code isn't available yet, links are 404'd.